### PR TITLE
Added SEO functionality in index.html

### DIFF
--- a/JS/script.js
+++ b/JS/script.js
@@ -1,4 +1,6 @@
-import { playerBtn, footBtn, controls, controlBtn, volume, progress, playbackSpeed, input, audio, img, array, /*play,*/ metadata, title, bgColor, bgColor2, elementColor, colorBtn, googleProxyURL, abstract, ytimg } from './constants.js';
+import { playerBtn, footBtn, controls, controlBtn, volume, progress, playbackSpeed, 
+  input, audio, img, array, /*play,*/ metadata, title, bgColor, bgColor2, elementColor,
+   colorBtn, googleProxyURL, abstract, ytimg } from './constants.js';
 
 const interval = setInterval(script, 2000);
 

--- a/index.html
+++ b/index.html
@@ -5,11 +5,16 @@
 
   <meta charset="UTF-8">
   <meta name="description" content="50kbps opus youtube audio streaming front-end">
-  <meta name="keywords" content="Youtube,Music,audio,opus,50kbps,Free">
   <meta name="author" content="Animesh Nath">
   <meta name="viewport" content="width=device-width, initial-scale=1.0,maximum-scale=1.0, user-scalable=no">
   <meta name="theme-color" content="#1f1f1f">
   <meta name="mobile-web-app-capable" content="yes">
+
+  <meta name="keywords" content="ytify, Ytify, Youtube, youtube, Music,music, audio,opus, 50kbps,Free , 
+     spotify ,streaming, music-player ,  youtube-player , free-music, ytmusic">
+  <meta name="description" content="Ytify is a minimal YouTube streaming front end app.
+   With ytify, you can stream YouTube audio in ultra-low bitrate at around 50kbps & 160kbps.
+    This saves your data and time!">
 
   <title>ytify</title>
 
@@ -18,9 +23,12 @@
   <meta property="og:url" content="https://ytify.netlify.app">
   <meta property="og:description" content="50kbps Opus YouTube Audio Streaming Web App.">
   <meta property="og:image" content="Assets/maskable_icon_x512.png">
+  
+  <!-- tells google that this url is most important (e.g. not http (without s = secure))-->
+  <link rel="canonical" href="https://ytify.netlify.app/">
 
-  <link rel="icon" type="image/png" sizes="512x512" href="Assets/maskable_icon_x512.png" />
-  <link rel="icon" type="image/png" sizes="192x192" href="Assets/maskable_icon_x192.png" />
+  <link rel="icon" type="image/png" alt="Main image" sizes="512x512" href="Assets/maskable_icon_x512.png" />
+  <link rel="icon" type="image/png" alt="Main image" sizes="192x192" href="Assets/maskable_icon_x192.png" />
   <link rel="manifest" href="manifest.json" />
   <link rel="stylesheet" href="style.css">
 </head>
@@ -28,7 +36,7 @@
 <body>
 
   <section>
-    <img class="hidden"></img>
+    <img class="hidden" ></img>
     <h3>YTIFY v4 apr-22</h3>
     <h5><span class="material-icons">fullscreen</span></h5>
     <input type="text" placeholder="paste link here" align="center" class="hidden">


### PR DESCRIPTION
# General
As outlined in  **"Google Search Engine does not show website #53"** , the website had missing SEO. This was now added in the **index.html** page.

## Improvements:
- alt tag to images
- more keywords
- a proper description
- added canoncial link tag to make the website searchable primarily under https://ytify.netlify.app/ which massively helps in SEO.
- ( made a line of JS more visible in script.js as it was hard to read)

## Important
This only makes the website better in terms of SEO.  Another great way to increase the rank of the website is to buy a domain hence .netlify.app domains are not as  optimized for SEO as "real" domains. 