### PR TITLE
#92

### DIFF
--- a/Stylesheets/data.css
+++ b/Stylesheets/data.css
@@ -28,7 +28,7 @@ img {
 
 #metadata {
   width: 100%;
-  overflow: break-word;
+  overflow: auto;
   padding-left: 2rem;
   padding-right: 1.5rem;
 }


### PR DESCRIPTION
Changed one line in Stylesheets/data.css
#metadata
had overflow: break-word
Chrome DevTools was seeing it as an Invalid property value.
Changed it to 'auto'.
Full title can be read by scrolling down.
Mobile view wasn't affected.