### PR TITLE
Fix the paths for the woff2 files in main.css

### DIFF
--- a/src/stylesheets/main.css
+++ b/src/stylesheets/main.css
@@ -1,12 +1,12 @@
 @font-face {
 	font-family: 'Noto Sans';
-	src: url("/assets/NotoSans.woff2") format("woff2");
+	src: url("../../assets/NotoSans.woff2") format("woff2");
 	font-display: swap;
 }
 
 @font-face {
 	font-family: "remixicon";
-	src: url("/assets/remixicon.woff2") format("woff2");
+	src: url("../../assets/remixicon.woff2") format("woff2");
 	font-display: swap;
 }
 


### PR DESCRIPTION
Hi, I found this repository by chance on Github and I thought it was interesting. When I ran it for the first time, I saw this:

![image](https://github.com/n-ce/ytify/assets/44126458/eaa3d36a-4b9d-448f-a574-ab150af86f8e)

As you can see, the icons are not showing properly. I looked in the console and saw this: 
![image](https://github.com/n-ce/ytify/assets/44126458/c21e9742-b471-4934-99af-9bba0769337d)

I saw that the path in `main.css` for these Woff2 files needed modification, as the old configuration was attempting to look into an assets folder that resided below main.css. With these changes the icons are now working:

![image](https://github.com/n-ce/ytify/assets/44126458/696a9ead-c32a-4f59-8373-ec0f53bc2311)
