### PR TITLE
feat(settings): add option to disable YT link autoplay

### DIFF
--- a/src/components/Settings/playback.ts
+++ b/src/components/Settings/playback.ts
@@ -39,6 +39,15 @@ export default function() {
     }
   })}
 
+  ${ToggleSwitch({
+    id: "disableYTLinkCapturing",
+    name: 'settings_disable_yt_link_capturing',
+    checked: Boolean(state.disableYTLinkCapturing),
+    handler: () => {
+      setState('disableYTLinkCapturing', !state.disableYTLinkCapturing);
+    }
+  })}
+
       ${!state.HLS ? html`
         ${Selector({
     label: 'settings_codec_preference',

--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -30,6 +30,7 @@ export let state = {
   shareAction: 'play' as 'play' | 'watch' | 'download',
   dbsync: '',
   language: 'en',
+  disableYTLinkCapturing: false,
   codec: 'any' as 'opus' | 'aac' | 'any',
   partsManagerPIN: '',
   'part Reserved Collections': true,

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -131,6 +131,7 @@
   "settings_roundness_lighter": "Lighter",
   "settings_roundness_light": "Light",
   "settings_roundness_heavy": "Heavy",
+  "settings_disable_yt_link_capturing": "Disable YT Link Capturing",
   "settings_roundness_heavier": "Heavier",
   "settings_use_custom_color": "Use Custom Color",
   "settings_custom_color_prompt": "Enter rgb in the format r,g,b",

--- a/src/scripts/search.ts
+++ b/src/scripts/search.ts
@@ -56,7 +56,9 @@ superInput.addEventListener('input', async () => {
 
   const id = idFromURL(text);
   if (id !== prevID) {
-    player(id);
+    if(!state.disableYTLinkCapturing){
+      player(id);
+    }
     prevID = id;
     return;
   }


### PR DESCRIPTION
- Added new setting under Settings > Search > Disable YT Link Capturing
- Wired toggle into Redux state for persistence
- Updated search logic to respect user preference
- Allows users to manually trigger playback instead of automatic autoplay