### PR TITLE
Fix: collection bug

### DIFF
--- a/src/components/CollectionSelector.ts
+++ b/src/components/CollectionSelector.ts
@@ -3,7 +3,7 @@ import { store } from '../lib/store';
 import { html } from 'uhtml';
 import { i18n } from '../scripts/i18n';
 
-export default function(_: {
+export default function (_: {
   collection: CollectionItem,
   close: () => void
 }) {
@@ -42,7 +42,7 @@ export default function(_: {
       e.target.selectedIndex = 0;
     }}
       >
-        <option>${i18n('collection_selector_add_to')}</option>
+        <option value="" disabled selected>${i18n('collection_selector_add_to')}</option>
         <option value="+cl">${i18n('collection_selector_create_new')}</option>
         <option value="favorites">${i18n('collection_selector_favorites')}</option>
         <option value="listenLater">${i18n('collection_selector_listen_later')}</option>


### PR DESCRIPTION
 Causing "Add To Collection" dropdown to unexpectedly close and behave like a popup.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Collection selector placeholder is now properly non-selectable, preventing accidental selection of an empty collection value.
  
  
<img width="628" height="276" alt="image" src="https://github.com/user-attachments/assets/f4daa38e-f5e7-466b-a530-68794f24b7d7" />


<!-- end of auto-generated comment: release notes by coderabbit.ai -->