### PR TITLE
Refactor navigation for exclusive main features and scrolling

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ytify",
-  "version": "8.3.24",
+  "version": "8.4-PR1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -16,34 +16,24 @@ export default function() {
 
       <i
         aria-label={t('nav_search')}
-        class={'ri-search-2-' + (navStore.search.state ? 'fill' : 'line')
+        class={'ri-search-2-' + (navStore.active === 'search' ? 'fill' : 'line')
         }
         classList={{
-          'on': navStore.search.state
+          'on': navStore.active === 'search'
         }}
         onclick={() => {
-          const state = !navStore.search.state;
-          setNavStore('search', 'state', state);
-          if (state) {
-            setNavStore('library', 'state', false);
-            navStore.search.ref?.scrollIntoView();
-            setDrawer('lastMainFeature', 'search');
-          }
+          setNavStore('active', 'search');
+          setDrawer('lastMainFeature', 'search');
         }}
       ></i>
 
       <i
         aria-label={t('nav_library')}
-        class={'ri-archive-stack-' + (navStore.library.state ? 'fill' : 'line')}
-        classList={{ 'on': navStore.library.state }}
+        class={'ri-archive-stack-' + (navStore.active === 'library' ? 'fill' : 'line')}
+        classList={{ 'on': navStore.active === 'library' }}
         onclick={() => {
-          const state = !navStore.library.state;
-          setNavStore('library', 'state', state);
-          if (state) {
-            setNavStore('search', 'state', false);
-            navStore.library.ref?.scrollIntoView();
-            setDrawer('lastMainFeature', 'library');
-          }
+          setNavStore('active', 'library');
+          setDrawer('lastMainFeature', 'library');
         }}
       ></i>
 

--- a/src/features/Library/Collections.tsx
+++ b/src/features/Library/Collections.tsx
@@ -125,7 +125,7 @@ export default function() {
               isShared: true,
               list: frequentlyPlayedItems as YTItem[],
             });
-            setNavStore('list', 'state', true);
+            setNavStore('active', 'list');
           }}
         >
           <i class="ri-bar-chart-2-fill"></i>
@@ -141,7 +141,7 @@ export default function() {
               isShared: true,
               list: discoveryItems as YTItem[],
             });
-            setNavStore('list', 'state', true);
+            setNavStore('active', 'list');
           }}
         >
           <i class="ri-compass-3-fill"></i>

--- a/src/features/List/index.tsx
+++ b/src/features/List/index.tsx
@@ -1,7 +1,7 @@
 import { createSignal, For, onMount, Show } from 'solid-js';
 import './List.css';
 import { addToQueue, listStore, resetList, setNavStore, t } from '@stores';
-import { fetchCollection, removeFromCollection, setConfig, config, drawer, generateImageUrl } from '@utils';
+import { fetchCollection, removeFromCollection, setConfig, config, generateImageUrl } from '@utils';
 import Dropdown from './Dropdown';
 import Results from './Results';
 import CollectionSelector from '@components/ActionsMenu/CollectionSelector';
@@ -22,8 +22,6 @@ export default function() {
   onMount(() => {
     setNavStore('list', 'ref', listSection);
     listSection.scrollIntoView();
-    listSection.scrollTo(0, 0);
-    setNavStore(drawer.lastMainFeature as 'search' | 'library', 'state', false);
   });
 
 

--- a/src/features/Search/index.tsx
+++ b/src/features/Search/index.tsx
@@ -40,7 +40,7 @@ export default function() {
             <i
               class="ri-settings-line"
               aria-label={t('nav_settings')}
-              onclick={() => setNavStore('settings', 'state', true)}
+              onclick={() => setNavStore('active', 'settings')}
             ></i>
           </Show>
         </div>

--- a/src/features/Search/index.tsx
+++ b/src/features/Search/index.tsx
@@ -36,7 +36,7 @@ export default function() {
               onclick={toggleFullScreen}
             ></i>
           </Show>
-          <Show when={!navStore.settings.state}>
+          <Show when={navStore.active !== 'settings'}>
             <i
               class="ri-settings-line"
               aria-label={t('nav_settings')}

--- a/src/features/Settings/index.tsx
+++ b/src/features/Settings/index.tsx
@@ -1,6 +1,6 @@
 import { onMount, createEffect, For, createSignal, Show } from "solid-js";
 import './Settings.css';
-import { closeFeature, setNavStore, t, setStore, updateLang } from '@stores';
+import { setNavStore, t, setStore, updateLang } from '@stores';
 import { Selector } from '@components/Selector.tsx';
 import { config, setConfig, drawer, setDrawer, cssVar, themer, quickSwitch, deleteCollection, getCollection } from '@utils';
 import Dropdown from "./Dropdown";
@@ -51,7 +51,7 @@ export default function() {
         <p>ytify {Build}</p>
         <i
           aria-label={t('close')}
-          class="ri-close-large-line" onclick={() => closeFeature('settings')}></i>
+          class="ri-close-large-line" onclick={() => setNavStore('active', drawer.lastMainFeature as 'search' | 'library')}></i>
         <Dropdown />
       </header>
       <div>

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,6 +1,6 @@
 /* @refresh reload */
 
-import { For, lazy, onMount, Show } from 'solid-js';
+import { lazy, onMount, Show } from 'solid-js';
 import { render } from 'solid-js/web';
 import { themer, syncLibrary } from '@utils';
 import NavBar from '@components/NavBar.tsx';
@@ -30,16 +30,27 @@ export default function App() {
     syncLibrary('init');
   });
 
+  const Search = navStore.search.component;
+  const Library = navStore.library.component;
+  const List = navStore.list.component;
+  const Settings = navStore.settings.component;
+  const Queue = navStore.queue.component;
+  const Player = navStore.player.component;
+
   return (
     <>
       <main>
-        <For each={Object.values(navStore)}>
-          {(item) =>
-            <Show when={item.state}>
-              <item.component />
-            </Show>
-          }
-        </For>
+        <Show when={navStore.queue.state}>
+          <Queue />
+        </Show>
+        <Show when={navStore.player.state}>
+          <Player />
+        </Show>
+
+        <Show when={navStore.active === 'search'}><Search /></Show>
+        <Show when={navStore.active === 'library'}><Library /></Show>
+        <Show when={navStore.active === 'list'}><List /></Show>
+        <Show when={navStore.active === 'settings'}><Settings /></Show>
       </main>
       <footer>
         <Show when={!navStore.player.state && playerStore.playbackState !== 'none'}>

--- a/src/lib/modules/start.ts
+++ b/src/lib/modules/start.ts
@@ -6,7 +6,7 @@ import { config, getDownloadLink, idFromURL, fetchCollection, player, setConfig,
 export default async function() {
 
   if (!params.size) {
-    setNavStore(drawer.lastMainFeature as 'search' | 'library', 'state', true);
+    setNavStore('active', drawer.lastMainFeature as 'search' | 'library');
   }
 
   // Handle /s/:id URLs by transforming them to /?s=id internally

--- a/src/lib/modules/start.ts
+++ b/src/lib/modules/start.ts
@@ -46,7 +46,7 @@ export default async function() {
     const f = params.get('f') || 'all';
     setConfig('searchFilter', f);
     setSearchStore('query', q);
-    setNavStore('search', 'state', true);
+    setNavStore('active', 'search');
   }
 
 

--- a/src/lib/stores/list.ts
+++ b/src/lib/stores/list.ts
@@ -1,5 +1,5 @@
 import { createStore } from "solid-js/store";
-import { closeFeature, navStore, setNavStore, updateParam, setStore, store } from "@stores";
+import { setNavStore, updateParam, setStore, store } from "@stores";
 import { getLibraryAlbums, drawer } from "@utils";
 
 const initialState = () => ({
@@ -33,10 +33,7 @@ export async function getList(
   setListStore('hasContinuation', false);
 
   setListStore('isLoading', true);
-  if (navStore.list.state)
-    navStore.list.ref?.scrollIntoView();
-  else
-    setNavStore('list', 'state', true);
+  setNavStore('active', 'list');
 
   if (!all) updateParam(type, id);
 
@@ -108,8 +105,7 @@ export async function getList(
 }
 
 export function resetList() {
-  setNavStore(drawer.lastMainFeature as 'search' | 'library', 'state', true);
-  closeFeature('list');
+  setNavStore('active', drawer.lastMainFeature as 'search' | 'library');
   listStore.observer.disconnect();
 
   updateParam('collection');

--- a/src/lib/stores/navigation.ts
+++ b/src/lib/stores/navigation.ts
@@ -11,13 +11,19 @@ const Settings = lazy(() => import('@features/Settings'));
 export const params = (new URL(location.href)).searchParams;
 
 
+export type MainFeature = 'search' | 'library' | 'list' | 'settings';
+export type Feature = MainFeature | 'queue' | 'player';
+
 type Nav = { [key in Features]: {
   ref: HTMLElement | null,
   state: boolean,
   component: () => JSX.Element
 } }
 
-export const [navStore, setNavStore] = createStore<Nav>({
+import { drawer } from "@utils";
+
+export const [navStore, setNavStore] = createStore<Nav & { active: MainFeature }>({
+  active: drawer.lastMainFeature as MainFeature,
   queue: { ref: null, state: false, component: Queue },
   player: { ref: null, state: false, component: Player },
   search: { ref: null, state: false, component: Search },
@@ -29,23 +35,6 @@ export const [navStore, setNavStore] = createStore<Nav>({
 
 
 export function closeFeature(name: Features) {
-  const keys = Object.keys(navStore);
-  const removedIndex = keys.indexOf(name);
-
-  const active = Object.entries(navStore)
-    .filter(f => f[1].state && f[0] !== name)
-    .sort((a, b) => {
-      const aa = Math.abs(keys.indexOf(a[0]) - removedIndex);
-      const bb = Math.abs(keys.indexOf(b[0]) - removedIndex);
-      return aa - bb;
-    });
-
-  const closestRef = active[0]?.[1]?.ref;
-
-  if (removedIndex >= 3)
-    closestRef?.scrollIntoView();
-
-
   setNavStore(name, { ref: null, state: false });
 }
 

--- a/src/lib/stores/navigation.ts
+++ b/src/lib/stores/navigation.ts
@@ -12,13 +12,21 @@ export const params = (new URL(location.href)).searchParams;
 
 
 export type MainFeature = 'search' | 'library' | 'list' | 'settings';
-export type Feature = MainFeature | 'queue' | 'player';
+export type SidePanel = 'queue' | 'player';
+export type Feature = MainFeature | SidePanel;
 
-type Nav = { [key in Features]: {
-  ref: HTMLElement | null,
-  state: boolean,
-  component: () => JSX.Element
-} }
+type Nav = { 
+  [key in MainFeature]: {
+    ref: HTMLElement | null,
+    component: () => JSX.Element
+  }
+} & {
+  [key in SidePanel]: {
+    ref: HTMLElement | null,
+    state: boolean,
+    component: () => JSX.Element
+  }
+}
 
 import { drawer } from "@utils";
 
@@ -26,16 +34,18 @@ export const [navStore, setNavStore] = createStore<Nav & { active: MainFeature }
   active: drawer.lastMainFeature as MainFeature,
   queue: { ref: null, state: false, component: Queue },
   player: { ref: null, state: false, component: Player },
-  search: { ref: null, state: false, component: Search },
-  library: { ref: null, state: false, component: Library },
-  list: { ref: null, state: false, component: List },
-  settings: { ref: null, state: false, component: Settings },
+  search: { ref: null, component: Search },
+  library: { ref: null, component: Library },
+  list: { ref: null, component: List },
+  settings: { ref: null, component: Settings },
 });
 
 
 
-export function closeFeature(name: Features) {
-  setNavStore(name, { ref: null, state: false });
+export function closeFeature(name: Feature) {
+  if (name === 'queue' || name === 'player') {
+    setNavStore(name, 'state', false);
+  }
 }
 
 type Params = 'q' | 's' | 'f' | 'collection' | 'playlist' | 'channel' | 'artist' | 'album' | 'si' | 't';

--- a/src/lib/utils/library.ts
+++ b/src/lib/utils/library.ts
@@ -297,11 +297,7 @@ export async function fetchCollection(
 ) {
   if (!id) return;
 
-  const { state, ref } = navStore.list;
-  if (state)
-    ref?.scrollIntoView();
-  else
-    setNavStore('list', 'state', true);
+  setNavStore('active', 'list');
 
   setListStore('isLoading', true);
 
@@ -325,7 +321,6 @@ export async function fetchCollection(
     updateParam('collection', id);
   }
 
-  setNavStore('list', 'state', true);
   setListStore('isLoading', false);
 
   document.title = display + ' - ytify';

--- a/src/lib/utils/library.ts
+++ b/src/lib/utils/library.ts
@@ -285,9 +285,9 @@ export function rehydrateStores() {
     fetchCollection(listStore.id);
   }
 
-  if (navStore.library.state) {
-    setNavStore('library', 'state', false);
-    setTimeout(() => setNavStore('library', 'state', true), 10);
+  if (navStore.active === 'library') {
+    setNavStore('active', '' as 'library');
+    setTimeout(() => setNavStore('active', 'library'), 10);
   }
 }
 


### PR DESCRIPTION
…ed panel scrolling

- Added 'active' property to navStore to track primary view (Search, Library, List, Settings).
- Updated index.tsx to render primary features exclusively in a single layout slot.
- Preserved side-by-side scrolling between side panels (Queue, Player) and the active main feature.
- Updated all navigation triggers (NavBar, Search, Settings, List) to use the new exclusive state.
- Ensured initial state respects URL parameters and user preferences (drawer.lastMainFeature).
- Removed legacy side-by-side state management for primary features.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Version bumped to 8.4-PR1.

* **Refactor**
  * Navigation streamlined so main sections (Search, Library, List, Settings) use a single active state — buttons behave mutually exclusively.
  * Settings now returns to the previously active main section when closed.
  * Startup and collection/list navigation behavior simplified for more consistent view activation and fewer automatic scroll/restore actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->