### PR TITLE
feat(lyrics): integrate MLC service & am-lyrics player

### DIFF
--- a/src/features/Player/Lyrics.tsx
+++ b/src/features/Player/Lyrics.tsx
@@ -1,11 +1,137 @@
-import { createSignal, For, onCleanup, createEffect } from "solid-js";
+import { createSignal, createEffect, onCleanup, JSX } from "solid-js";
 import { playerStore, setPlayerStore, setStore, t } from "@stores";
+import '@uimaxbai/am-lyrics/am-lyrics.js';
+
+interface MlcWord {
+  text: string;
+  time?: number;
+  duration?: number;
+}
+
+interface MlcLine {
+  text?: string;
+  time?: number;
+  duration?: number;
+  syllabus?: MlcWord[];
+}
+
+interface AmLyricsAttributes {
+  ref?: any;
+  'prop:ttml'?: string;
+  'prop:currentTime'?: number;
+  'prop:songTitle'?: string;
+  'prop:songArtist'?: string;
+  'prop:fontFamily'?: string;
+  'prop:highlightColor'?: string;
+  autoscroll?: boolean;
+  interpolate?: boolean;
+  'on:line-click'?: (e: CustomEvent<{ timestamp: number }>) => void;
+  style?: string | JSX.CSSProperties;
+}
+
+declare module "solid-js" {
+  namespace JSX {
+    interface IntrinsicElements {
+      'am-lyrics': AmLyricsAttributes;
+    }
+  }
+}
+
+function xmlEscape(str: string): string {
+  return str.replace(/[&<>]/g, (match) => {
+    switch (match) {
+      case '&': return '&amp;';
+      case '<': return '&lt;';
+      case '>': return '&gt;';
+      default: return match;
+    }
+  });
+}
+
+function formatMsToTTML(ms: number): string {
+  const hours = Math.floor(ms / 3600000);
+  const minutes = Math.floor((ms % 3600000) / 60000);
+  const seconds = ((ms % 60000) / 1000).toFixed(3).padStart(6, '0');
+  const pad = (num: number) => String(num).padStart(2, '0');
+  return `${pad(hours)}:${pad(minutes)}:${seconds}`;
+}
+
+function jsonToTTML(lyricsList: MlcLine[]): string {
+  let ttml = `<?xml version="1.0" encoding="UTF-8"?>
+<tt xmlns="http://www.w3.org/ns/ttml" xmlns:itunes="http://music.apple.com/lyrics">
+  <body>
+    <div>\n`;
+
+  lyricsList.forEach((line: MlcLine, index: number) => {
+    const beginMs = line.time || 0;
+    let endMs = beginMs + (line.duration || 0);
+    
+    if (!line.duration) {
+      if (index < lyricsList.length - 1) {
+        endMs = lyricsList[index + 1].time || (beginMs + 3000);
+      } else {
+        endMs = beginMs + 5000;
+      }
+    }
+
+    const begin = formatMsToTTML(beginMs);
+    const end = formatMsToTTML(endMs);
+
+    ttml += `      <p begin="${begin}" end="${end}">\n`;
+    if (Array.isArray(line.syllabus) && line.syllabus.length > 0) {
+      line.syllabus.forEach((word: MlcWord) => {
+        const wBegin = formatMsToTTML(word.time || 0);
+        const wEnd = formatMsToTTML((word.time || 0) + (word.duration || 0));
+        ttml += `        <span begin="${wBegin}" end="${wEnd}">${xmlEscape(word.text)}</span>\n`;
+      });
+    } else {
+      ttml += `        ${xmlEscape(line.text || '')}\n`;
+    }
+    ttml += `      </p>\n`;
+  });
+
+  ttml += `    </div>
+  </body>
+</tt>`;
+  return ttml;
+}
+
+function lrcToTTML(lrcString: string): string {
+  const lines = lrcString.split('\n');
+  const parsedLines: MlcLine[] = [];
+
+  lines.forEach((line) => {
+    const match = line.match(/^\[(\d+):(\d+(?:\.\d+)?)\](.*)/);
+    if (match) {
+      const minutes = parseInt(match[1], 10);
+      const seconds = parseFloat(match[2]);
+      const timeMs = Math.round((minutes * 60 + seconds) * 1000);
+      const text = match[3].trim();
+      parsedLines.push({ time: timeMs, text });
+    }
+  });
+
+  return jsonToTTML(parsedLines);
+}
+
+function plainToTTML(plainString: string): string {
+  const lines = plainString.split('\n');
+  let ttml = `<?xml version="1.0" encoding="UTF-8"?>
+<tt xmlns="http://www.w3.org/ns/ttml" xmlns:itunes="http://music.apple.com/lyrics">
+  <body>
+    <div>\n`;
+  lines.forEach((line) => {
+    ttml += `      <p>${xmlEscape(line.trim())}</p>\n`;
+  });
+  ttml += `    </div>
+  </body>
+</tt>`;
+  return ttml;
+}
 
 export default function(props: { onClose: () => void }) {
-
-  const [lrcMap, setLrcMap] = createSignal([t('loading')]);
-  const [activeLine, setActiveLine] = createSignal(-1);
-  let lyricsSection!: HTMLDivElement;
+  const [ttml, setTtml] = createSignal<string>("");
+  const [currentTime, setCurrentTime] = createSignal(0);
 
   createEffect(() => {
     const { title, author, id } = playerStore.stream;
@@ -16,73 +142,26 @@ export default function(props: { onClose: () => void }) {
       return;
     }
 
-    setLrcMap([t('loading')]);
-    setActiveLine(-1);
+    setTtml("");
+    setCurrentTime(0);
     setPlayerStore('lrcSync', undefined);
 
+    const artistName = author.endsWith(' - Topic') ? author.slice(0, -8) : author;
     fetch(
-      `https://lrclib.net/api/get?track_name=${title}&artist_name=${author.slice(0, -8)}&duration=${playerStore.fullDuration}`,
-      {
-        headers: {
-          'Lrclib-Client': `ytify ${Build} (https://github.com/n-ce/ytify)`
-        }
-      })
+      `https://mlc-ytify.kouzu.in/api/lyrics/${id}?name=${encodeURIComponent(title)}&artist=${encodeURIComponent(artistName)}`
+    )
       .then(res => res.json())
       .then(data => {
-
-        const lrc = data.syncedLyrics;
-        const fetchedDuration = data.duration;
-        const localDuration = playerStore.fullDuration;
-
-        let offset = 0;
-        if (fetchedDuration && localDuration) {
-          offset = (localDuration - fetchedDuration) / 2;
-        }
-
-        if (lrc) {
-          const durarr: number[] = [];
-          const lrcMap: string[] = lrc
-            .split('\n')
-            .map((line: string) => {
-              const [d, l] = line.split(']');
-              if (!l) return '...';
-              const [mm, ss] = d.substring(1).split(':');
-              const s = (parseInt(mm) * 60) + parseFloat(ss);
-              durarr.push(s - offset);
-              return l;
-            });
-          setLrcMap(lrcMap);
-
-
-          setPlayerStore({
-            lrcSync: (d: number) => {
-              let currentIndex = -1;
-              const { length } = durarr;
-              for (let i = 0; i < length; i++) {
-                if (durarr[i] <= d) {
-                  currentIndex = i;
-                } else {
-                  break;
-                }
-              }
-
-              if (currentIndex !== activeLine()) {
-                setActiveLine(currentIndex);
-
-                if (currentIndex < 0) return;
-
-                if (lyricsSection.children[currentIndex]) {
-                  lyricsSection.children[currentIndex].scrollIntoView({
-                    block: 'center',
-                    behavior: 'smooth'
-                  });
-                }
-              }
-            }
-          });
-
-        }
-        else {
+        if (Array.isArray(data.lyrics) && data.lyrics.length > 0) {
+          const generatedTtml = jsonToTTML(data.lyrics);
+          setTtml(generatedTtml);
+        } else if (data.syncedLyrics) {
+          const generatedTtml = lrcToTTML(data.syncedLyrics);
+          setTtml(generatedTtml);
+        } else if (data.plainLyrics) {
+          const generatedTtml = plainToTTML(data.plainLyrics);
+          setTtml(generatedTtml);
+        } else {
           setStore('snackbar', t('lyrics_no_found'));
           props.onClose();
         }
@@ -92,18 +171,110 @@ export default function(props: { onClose: () => void }) {
       });
   });
 
+  createEffect(() => {
+    if (!ttml()) return;
+
+    const audio = playerStore.audio;
+    if (!audio) return;
+
+    let frameId: number;
+
+    const oneShotUpdate = () => {
+      setCurrentTime(audio.currentTime * 1000);
+    };
+
+    const tick = () => {
+      oneShotUpdate();
+      frameId = requestAnimationFrame(tick);
+    };
+
+    const onPlay = () => {
+      cancelAnimationFrame(frameId);
+      frameId = requestAnimationFrame(tick);
+    };
+
+    const onPause = () => {
+      cancelAnimationFrame(frameId);
+    };
+
+    audio.addEventListener('play', onPlay);
+    audio.addEventListener('pause', onPause);
+    audio.addEventListener('seeking', oneShotUpdate);
+    audio.addEventListener('seeked', oneShotUpdate);
+
+    if (!audio.paused) {
+      onPlay();
+    } else {
+      oneShotUpdate();
+    }
+
+    onCleanup(() => {
+      cancelAnimationFrame(frameId);
+      audio.removeEventListener('play', onPlay);
+      audio.removeEventListener('pause', onPause);
+      audio.removeEventListener('seeking', oneShotUpdate);
+      audio.removeEventListener('seeked', oneShotUpdate);
+    });
+  });
+
   onCleanup(() => {
     setPlayerStore('lrcSync', undefined);
   });
 
+  let amLyricsRef: any;
+
+  createEffect(() => {
+    const el = amLyricsRef;
+    if (!el) return;
+
+    const listener = (e: CustomEvent<{ timestamp: number }>) => {
+      const seekMs = e.detail?.timestamp;
+      if (typeof seekMs === 'number') {
+        const audio = playerStore.audio;
+        if (audio) {
+          audio.currentTime = seekMs / 1000;
+          audio.play().catch(() => {});
+        }
+      }
+    };
+
+    el.addEventListener('line-click', listener);
+    onCleanup(() => {
+      el.removeEventListener('line-click', listener);
+    });
+  });
+
   return (
-    <div ref={lyricsSection} class="lyrics">
-      <For each={lrcMap()}>
-        {(item, i) => (
-          <p
-            classList={{ active: activeLine() === i() }}
-          >{item}</p>)}
-      </For>
+    <div class="lyrics" style={{
+      display: "flex",
+      "flex-direction": "column",
+      background: "var(--bg)",
+      padding: "0",
+      overflow: "hidden"
+    }}>
+      {ttml() ? (
+        <am-lyrics
+          ref={amLyricsRef}
+          prop:ttml={ttml()}
+          prop:currentTime={currentTime()}
+          prop:songTitle={playerStore.stream.title}
+          prop:songArtist={playerStore.stream.author}
+          prop:fontFamily="var(--font)"
+          autoscroll
+          interpolate
+          style={{
+            height: "100%",
+            width: "100%",
+            "--highlight-color": "var(--text)",
+            "--am-lyrics-highlight-color": "var(--text)",
+            "--lyplus-lyrics-palette": "var(--text)",
+            "--lyplus-text-primary": "var(--text)",
+            "--lyplus-text-secondary": "color-mix(in srgb, var(--text) 30%, transparent)"
+          }}
+        />
+      ) : (
+        <p style={{ "text-align": "center", "margin-top": "2rem", "color": "var(--text2)" }}>{t('loading')}</p>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
- Migrated lyrics API to fetch from https://mlc-ytify.kouzu.in/ (a custom version of MLC https://mlc.kouzu.in/ specifically designed for ytify).
- Replaced the custom lyrics renderer with the @uimaxbai/am-lyrics web component.
- Implemented robust format parsers (jsonToTTML, lrcToTTML, plainToTTML) with XML escaping to translate Line, Word, LRC, and plain lyrics into TTML.
- Setup an ultra-smooth requestAnimationFrame synchronization loop (60fps+) tied directly to media player playback, with one-shot progress updates on seeks.
- Fixed click-to-seek by binding a DOM event listener directly to the component ref, bypassing SolidJS JSX dashed custom event limitations.
- Styled the player container with a static theme background (var(--bg)) to disable dynamic cover art tinting, and customized text highlight/opacity.
- Upgraded dependencies (solid-js, typescript, vite, youtubei.js, @netlify/blobs) and resolved vite-plugin-pwa peer conflicts.